### PR TITLE
Update markdown pages for Hugo integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+<!--
+---
+title: cc-lib
+description: Component library for various ClusterCockpit applications
+categories: [cc-lib]
+tags: ['Admin', 'Developer']
+weight: 1
+hugo_path: docs/reference/cc-lib/_index.md
+---
+-->
+
 # cc-lib
 
 Common ClusterCockpit golang packages:

--- a/ccConfig/README.md
+++ b/ccConfig/README.md
@@ -1,0 +1,31 @@
+<!--
+---
+title: ClusterCockpit configuration component
+description: Description of ClusterCockpit's configuration component
+categories: [cc-lib]
+tags: ['Admin', 'Developer']
+weight: 2
+hugo_path: docs/reference/cc-lib/ccConfig/_index.md
+---
+-->
+
+# ccConfig interface
+
+The ccConfig component is an approach to read in JSON configuration files in the
+ClusterCockpit ecosystem. All configuration files have the following structure:
+
+```json
+{
+    "main" : {
+        // Main configuration for component
+    },
+    "foo" : {
+        // Configuration for the sub-component 'foo'
+    }
+    "bar" : "bar.json"
+}
+```
+
+After initializing the ccConfig component with `Init(filename)`, the individual
+configuration sections can be retrieved with `GetPackageConfig("key")`. It always
+returns the content as `json.RawMessage` and has to be converted as needed.

--- a/ccLogger/README.md
+++ b/ccLogger/README.md
@@ -1,0 +1,16 @@
+<!--
+---
+title: ClusterCockpit logger
+description: Description of ClusterCockpit logging interface
+categories: [cc-lib]
+tags: ['Admin', 'Developer']
+weight: 2
+hugo_path: docs/reference/cc-lib/ccLogger/_index.md
+---
+-->
+
+# ccLogger interface
+
+The ccLogger component is an approach to unify logging over the various
+components of ClusterCockpit. It is suitable to work with systemd's journaling.
+

--- a/ccMessage/README.md
+++ b/ccMessage/README.md
@@ -1,3 +1,14 @@
+<!--
+---
+title: ClusterCockpit messages
+description: Description of ClusterCockpit message format and interface
+categories: [cc-lib]
+tags: ['Admin', 'Developer']
+weight: 2
+hugo_path: docs/reference/cc-lib/ccMessage/_index.md
+---
+-->
+
 # ClusterCockpit messages
 
 As described in the [ClusterCockpit specifications](https://github.com/ClusterCockpit/cc-specifications), the whole ClusterCockpit stack uses metrics, events and control in the InfluxDB line protocol format. This is also the input and output format for the ClusterCockpit Metric Collector but internally it uses an extended format while processing, named CCMessage.

--- a/messageProcessor/README.md
+++ b/messageProcessor/README.md
@@ -1,3 +1,15 @@
+<!--
+---
+title: Message processor for ClusterCockpit
+description: Message processor for filtering and manipulating ClusterCockpit messages
+categories: [cc-lib]
+tags: ['Admin', 'Developer']
+weight: 2
+hugo_path: docs/reference/cc-lib/messageProcessor/_index.md
+---
+-->
+
+
 # Message Processor Component
 
 Multiple parts of in the ClusterCockit ecosystem require the processing of CCMessages.

--- a/messageProcessor/README.md
+++ b/messageProcessor/README.md
@@ -12,7 +12,7 @@ hugo_path: docs/reference/cc-lib/messageProcessor/_index.md
 
 # Message Processor Component
 
-Multiple parts of in the ClusterCockit ecosystem require the processing of CCMessages.
+Multiple parts of in the ClusterCockpit ecosystem require the processing of CCMessages.
 The main CC application using it is `cc-metric-collector`. The processing part there was originally in the metric router, the central
 hub connecting collectors (reading local data), receivers (receiving remote data) and sinks (sending data). Already in early stages, the
 lack of flexibility caused some trouble:

--- a/receivers/README.md
+++ b/receivers/README.md
@@ -34,10 +34,10 @@ This allows to specify
 - [`prometheus`](./prometheusReceiver.md): Scrape data from a Prometheus client
 - [`http`](./httpReceiver.md): Listen for HTTP Post requests transporting metrics in InfluxDB line protocol
 - [`ipmi`](./ipmiReceiver.md): Read IPMI sensor readings
-- [`redfish`](redfishReceiver.md) Use the Redfish (specification) to query thermal and power metrics
+- [`redfish`](./redfishReceiver.md) Use the Redfish (specification) to query thermal and power metrics
 
 ## Contributing own receivers
 
 A receiver contains a few functions and is derived from the type `Receiver` (in `metricReceiver.go`):
 
-For an example, check the [sample receiver](./sampleReceiver.go)
+For an example, check the [sample receiver](https://github.com/ClusterCockpit/cc-lib/blob/main/receivers/sampleReceiver.go)

--- a/receivers/README.md
+++ b/receivers/README.md
@@ -1,3 +1,14 @@
+<!--
+---
+title: Message receivers
+description: Message receivers for ClusterCockpit
+categories: [cc-lib]
+tags: ['Admin', 'Developer']
+weight: 2
+hugo_path: docs/reference/cc-lib/receivers/_index.md
+---
+-->
+
 # CCMetric receivers
 
 This folder contains the ReceiveManager and receiver implementations for the cc-metric-collector.

--- a/receivers/httpReceiver.md
+++ b/receivers/httpReceiver.md
@@ -1,3 +1,14 @@
+<!--
+---
+title: Message receiver for HTTP
+description: Receiving messages over HTTP from remote sources
+categories: [cc-lib]
+tags: ['Admin', 'Developer']
+weight: 2
+hugo_path: docs/reference/cc-lib/receivers/http.md
+---
+-->
+
 ## `http` receiver
 
 The `http` receiver can be used receive metrics through HTTP POST requests.

--- a/receivers/ipmiReceiver.md
+++ b/receivers/ipmiReceiver.md
@@ -1,3 +1,14 @@
+<!--
+---
+title: Message receiver for IPMI endpoints
+description: Query metrics from remote IPMI sources
+categories: [cc-lib]
+tags: ['Admin', 'Developer']
+weight: 2
+hugo_path: docs/reference/cc-lib/receivers/ipmi.md
+---
+-->
+
 ## IPMI Receiver
 
 The IPMI Receiver uses `ipmi-sensors` from the [FreeIPMI](https://www.gnu.org/software/freeipmi/) project to read IPMI sensor readings and sensor data repository (SDR) information. The available metrics depend on the sensors provided by the hardware vendor but typically contain temperature, fan speed, voltage and power metrics.

--- a/receivers/natsReceiver.go
+++ b/receivers/natsReceiver.go
@@ -1,3 +1,15 @@
+<!--
+---
+title: Message receiver for IPMI endpoint
+description: Query metrics from remote IPMI sources
+categories: [cc-lib]
+tags: ['Admin', 'Developer']
+weight: 2
+hugo_path: docs/reference/cc-lib/receivers/ipmi.md
+---
+-->
+
+
 // Copyright (C) NHR@FAU, University Erlangen-Nuremberg.
 // All rights reserved. This file is part of cc-lib.
 // Use of this source code is governed by a MIT-style

--- a/receivers/natsReceiver.md
+++ b/receivers/natsReceiver.md
@@ -1,3 +1,15 @@
+<!--
+---
+title: Message receiver for NATS pub-sub networks
+description: Message receiver for NATS pub-sub networks
+categories: [cc-lib]
+tags: ['Admin', 'Developer']
+weight: 2
+hugo_path: docs/reference/cc-lib/receivers/nats.md
+---
+-->
+
+
 ## `nats` receiver
 
 The `nats` receiver can be used receive metrics from the NATS network. The `nats` receiver subscribes to the topic `database` and listens on `address` and `port` for metrics in the InfluxDB line protocol.

--- a/receivers/prometheusReceiver.md
+++ b/receivers/prometheusReceiver.md
@@ -1,3 +1,15 @@
+<!--
+---
+title: Message scraper for Prometheus
+description: Message scraper for Prometheus monitoring endpoints
+categories: [cc-lib]
+tags: ['Admin', 'Developer']
+weight: 2
+hugo_path: docs/reference/cc-lib/receivers/prometheus.md
+---
+-->
+
+
 ## `prometheus` receiver
 
 The `prometheus` receiver can be used to scrape the metrics of a single `prometheus` client. It does **not** use any official Golang library but making simple HTTP get requests and parse the response.

--- a/receivers/redfishReceiver.md
+++ b/receivers/redfishReceiver.md
@@ -1,3 +1,14 @@
+<!--
+---
+title: Message receiver for Redfish endpoints
+description: Query metrics from remote Redfish sources
+categories: [cc-lib]
+tags: ['Admin', 'Developer']
+weight: 2
+hugo_path: docs/reference/cc-lib/receivers/redfish.md
+---
+-->
+
 ## Redfish receiver
 
 The Redfish receiver uses the [Redfish (specification)](https://www.dmtf.org/standards/redfish) to query thermal and power metrics. Thermal metrics may include various fan speeds and temperatures. Power metrics may include the current power consumption of various hardware components. It may also include the minimum, maximum and average power consumption of these components in a given time interval. The receiver will poll each configured redfish device once in a given interval. Multiple devices can be accessed in parallel to increase throughput.

--- a/sinks/README.md
+++ b/sinks/README.md
@@ -1,3 +1,14 @@
+<!--
+---
+title: Message sinks
+description: Message sinks for ClusterCockpit
+categories: [cc-lib]
+tags: ['Admin', 'Developer']
+weight: 2
+hugo_path: docs/reference/cc-lib/sinks/_index.md
+---
+-->
+
 # CCMetric sinks
 
 This folder contains the SinkManager and sink implementations for the cc-metric-collector.

--- a/sinks/gangliaSink.md
+++ b/sinks/gangliaSink.md
@@ -32,5 +32,5 @@ The `ganglia` sink uses the `gmetric` tool of the [Ganglia Monitoring System](ht
 - `type`: makes the sink an `ganglia` sink
 - `gmetric_path`: Path to `gmetric` executable (optional). If not given, the sink searches in `$PATH` for `gmetric`.
 - `add_ganglia_group`: Add `--group=X` based on meta information to the `gmetric` call. Some old versions of `gmetric` do not support the `--group` option.
-- `process_messages`: Process messages with given rules before progressing or dropping, see [here](../pkg/messageProcessor/README.md) (optional)
+- `process_messages`: Process messages with given rules before progressing or dropping, see [here](../messageProcessor/README.md) (optional)
 - `meta_as_tags`: print all meta information as tags in the output (deprecated, optional)

--- a/sinks/gangliaSink.md
+++ b/sinks/gangliaSink.md
@@ -1,3 +1,14 @@
+<!--
+---
+title: Message sink to Ganglia
+description: Message sink for Ganglia monitoring system using `gmetric`
+categories: [cc-lib]
+tags: ['Admin', 'Developer']
+weight: 2
+hugo_path: docs/reference/cc-lib/sinks/ganglia.md
+---
+-->
+
 ## `ganglia` sink
 
 The `ganglia` sink uses the `gmetric` tool of the [Ganglia Monitoring System](http://ganglia.info/) to submit the metrics

--- a/sinks/httpSink.md
+++ b/sinks/httpSink.md
@@ -47,7 +47,7 @@ The `http` sink uses POST requests to a HTTP server to submit the metrics in the
 - `flush_delay`: Batch all writes arriving in during this duration (default '1s', batching can be disabled by setting it to 0)
 - `batch_size`: Maximal batch size. If `batch_size` is reached before the end of `flush_delay`, the metrics are sent without further delay
 - `precision`: Precision of the timestamp. Valid values are 's', 'ms', 'us' and 'ns'. (default is 's')
-- `process_messages`: Process messages with given rules before progressing or dropping, see [here](../pkg/messageProcessor/README.md) (optional)
+- `process_messages`: Process messages with given rules before progressing or dropping, see [here](../messageProcessor/README.md) (optional)
 - `meta_as_tags`: print all meta information as tags in the output (deprecated, optional)
 
 ### Using `http` sink for communication with cc-metric-store

--- a/sinks/httpSink.md
+++ b/sinks/httpSink.md
@@ -1,3 +1,14 @@
+<!--
+---
+title: Message sink to HTTP
+description: Message sink for HTTP endpoints
+categories: [cc-lib]
+tags: ['Admin', 'Developer']
+weight: 2
+hugo_path: docs/reference/cc-lib/sinks/http.md
+---
+-->
+
 ## `http` sink
 
 The `http` sink uses POST requests to a HTTP server to submit the metrics in the InfluxDB line-protocol format. It uses JSON web tokens for authentification. The sink creates batches of metrics before sending, to reduce the HTTP traffic.

--- a/sinks/influxAsyncSink.md
+++ b/sinks/influxAsyncSink.md
@@ -56,7 +56,7 @@ The `influxasync` sink uses the official [InfluxDB golang client](https://pkg.go
 - `max_retries`: Maximal number of retry attempts
 - `max_retry_time`: Maximal time to retry failed writes, default 168h (one week)
 - `precision`: Precision of the timestamp. Valid values are 's', 'ms', 'us' and 'ns'. (default is 's')
-- `process_messages`: Process messages with given rules before progressing or dropping, see [here](../pkg/messageProcessor/README.md) (optional)
+- `process_messages`: Process messages with given rules before progressing or dropping, see [here](../messageProcessor/README.md) (optional)
 - `meta_as_tags`: print all meta information as tags in the output (deprecated, optional)
 
 For information about the calculation of the retry interval settings, see [offical influxdb-client-go documentation](https://github.com/influxdata/influxdb-client-go#handling-of-failed-async-writes)

--- a/sinks/influxAsyncSink.md
+++ b/sinks/influxAsyncSink.md
@@ -1,3 +1,15 @@
+<!--
+---
+title: Message sink to InfluxDB (async)
+description: Message sink for InfluxDB using asynchronous sending methods
+categories: [cc-lib]
+tags: ['Admin', 'Developer']
+weight: 2
+hugo_path: docs/reference/cc-lib/sinks/influx_async.md
+---
+-->
+
+
 ## `influxasync` sink
 
 The `influxasync` sink uses the official [InfluxDB golang client](https://pkg.go.dev/github.com/influxdata/influxdb-client-go/v2) to write the metrics to an InfluxDB database in a **non-blocking** fashion. It provides only support for V2 write endpoints (InfluxDB 1.8.0 or later).

--- a/sinks/influxSink.md
+++ b/sinks/influxSink.md
@@ -49,7 +49,7 @@ The `influxdb` sink uses the official [InfluxDB golang client](https://pkg.go.de
 - `flush_delay`: Group metrics coming in to a single batch
 - `batch_size`: Maximal batch size. If `batch_size` is reached before the end of `flush_delay`, the metrics are sent without further delay
 - `precision`: Precision of the timestamp. Valid values are 's', 'ms', 'us' and 'ns'. (default is 's')
-- `process_messages`: Process messages with given rules before progressing or dropping, see [here](../pkg/messageProcessor/README.md) (optional)
+- `process_messages`: Process messages with given rules before progressing or dropping, see [here](../messageProcessor/README.md) (optional)
 - `meta_as_tags`: print all meta information as tags in the output (deprecated, optional)
 
 Influx client options:

--- a/sinks/influxSink.md
+++ b/sinks/influxSink.md
@@ -1,3 +1,14 @@
+<!--
+---
+title: Message sink to InfluxDB
+description: Message sink for InfluxDB
+categories: [cc-lib]
+tags: ['Admin', 'Developer']
+weight: 2
+hugo_path: docs/reference/cc-lib/sinks/influx.md
+---
+-->
+
 ## `influxdb` sink
 
 The `influxdb` sink uses the official [InfluxDB golang client](https://pkg.go.dev/github.com/influxdata/influxdb-client-go/v2) to write the metrics to an InfluxDB database in a **blocking** fashion. It provides only support for V2 write endpoints (InfluxDB 1.8.0 or later).

--- a/sinks/libgangliaSink.md
+++ b/sinks/libgangliaSink.md
@@ -41,7 +41,7 @@ The `libganglia` sink has probably less overhead compared to the `ganglia` sink 
 - `add_ganglia_group`: Add a Ganglia metric group based on meta information. Some old versions of `gmetric` do not support the `--group` option
 - `add_type_to_name`: Ganglia commonly uses only node-level metrics but with cc-metric-collector, there are metrics for cpus, memory domains, CPU sockets and the whole node. In order to get  eeng, this option prefixes the metric name with `<type><type-id>_` or `device_` depending on the metric tags and meta information. For metrics of the whole node `type=node`, no prefix is added
 - `add_units`: Add metric value unit if there is a `unit` entry in the metric tags or meta information
-- `process_messages`: Process messages with given rules before progressing or dropping, see [here](../pkg/messageProcessor/README.md)  (optional)
+- `process_messages`: Process messages with given rules before progressing or dropping, see [here](../messageProcessor/README.md)  (optional)
 - `meta_as_tags`: print all meta information as tags in the output (deprecated, optional)
 
 ### Ganglia Installation

--- a/sinks/libgangliaSink.md
+++ b/sinks/libgangliaSink.md
@@ -1,3 +1,14 @@
+<!--
+---
+title: Message sink to Ganglia
+description: Message sink for Ganglia monitoring system using `libganglia`
+categories: [cc-lib]
+tags: ['Admin', 'Developer']
+weight: 2
+hugo_path: docs/reference/cc-lib/sinks/libganglia.md
+---
+-->
+
 ## `libganglia` sink
 
 The `libganglia` sink interacts directly with the library of the [Ganglia Monitoring System](http://ganglia.info/) to submit the metrics. Consequently, it needs to be installed on all nodes. But this is commonly the case if you want to use Ganglia, because it requires at least a node daemon (`gmond` or `ganglia-monitor`) to work.

--- a/sinks/natsSink.md
+++ b/sinks/natsSink.md
@@ -1,3 +1,15 @@
+<!--
+---
+title: Message sink to NATS
+description: Message sink to NATS pub/sub network
+categories: [cc-lib]
+tags: ['Admin', 'Developer']
+weight: 2
+hugo_path: docs/reference/cc-lib/sinks/nats.md
+---
+-->
+
+
 ## `nats` sink
 
 The `nats` sink publishes all metrics into a NATS network. The publishing key is the database name provided in the configuration file

--- a/sinks/natsSink.md
+++ b/sinks/natsSink.md
@@ -45,7 +45,7 @@ The `nats` sink publishes all metrics into a NATS network. The publishing key is
 - `nkey_file`: Path to credentials file with NKEY
 - `flush_delay`: Maximum time until metrics are sent out (default '5s')
 - `precision`: Precision of the timestamp. Valid values are 's', 'ms', 'us' and 'ns'. (default is 's')
-- `process_messages`: Process messages with given rules before progressing or dropping, see [here](../pkg/messageProcessor/README.md)  (optional)
+- `process_messages`: Process messages with given rules before progressing or dropping, see [here](../messageProcessor/README.md)  (optional)
 - `meta_as_tags`: print all meta information as tags in the output (deprecated, optional)
 
 ### Using `nats` sink for communication with cc-metric-store

--- a/sinks/prometheusSink.md
+++ b/sinks/prometheusSink.md
@@ -1,3 +1,15 @@
+<!--
+---
+title: Message sink to mimic a Prometheus endpoint
+description: Message sink to mimic a Prometheus endpoint
+categories: [cc-lib]
+tags: ['Admin', 'Developer']
+weight: 2
+hugo_path: docs/reference/cc-lib/sinks/prometheus.md
+---
+-->
+
+
 ## `prometheus` sink
 
 The `prometheus` sink publishes all metrics via an HTTP server ready to be scraped by a [Prometheus](https://prometheus.io) server. It creates gauge metrics for all node metrics and gauge vectors for all metrics with a subtype like 'device', 'cpu' or 'socket'. 

--- a/sinks/prometheusSink.md
+++ b/sinks/prometheusSink.md
@@ -37,5 +37,5 @@ The `prometheus` sink publishes all metrics via an HTTP server ready to be scrap
 - `port`: Portnumber (as string) for the HTTP server
 - `path`: Path where the metrics should be servered. The metrics will be published at `host`:`port`/`path`
 - `group_as_namespace`: Most metrics contain a group as meta information like 'memory', 'load'. With this the metric names are extended to `group`_`name` if possible.
-- `process_messages`: Process messages with given rules before progressing or dropping, see [here](../pkg/messageProcessor/README.md) (optional)
+- `process_messages`: Process messages with given rules before progressing or dropping, see [here](../messageProcessor/README.md) (optional)
 - `meta_as_tags`: print all meta information as tags in the output (deprecated, optional)

--- a/sinks/stdoutSink.md
+++ b/sinks/stdoutSink.md
@@ -1,3 +1,15 @@
+<!--
+---
+title: Message sink to stdout or file
+description: Message sink to stdout or file
+categories: [cc-lib]
+tags: ['Admin', 'Developer']
+weight: 2
+hugo_path: docs/reference/cc-lib/sinks/stdout.md
+---
+-->
+
+
 ## `stdout` sink
 
 The `stdout` sink is the most simple sink provided by cc-metric-collector. It writes all metrics in InfluxDB line-procol format to the configurable output file or the common special files `stdout` and `stderr`.

--- a/sinks/stdoutSink.md
+++ b/sinks/stdoutSink.md
@@ -34,6 +34,6 @@ The `stdout` sink is the most simple sink provided by cc-metric-collector. It wr
 - `type`: makes the sink an `stdout` sink
 - `meta_as_tags`: print meta information as tags in the output (optional)
 - `output_file`: Write all data to the selected file (optional). There are two 'special' files: `stdout` and `stderr`. If this option is not provided, the default value is `stdout`
-- `process_messages`: Process messages with given rules before progressing or dropping, see [here](../pkg/messageProcessor/README.md)  (optional)
+- `process_messages`: Process messages with given rules before progressing or dropping, see [here](../messageProcessor/README.md)  (optional)
 - `meta_as_tags`: print all meta information as tags in the output (deprecated, optional)
 


### PR DESCRIPTION
This PR adds Hugo YAML blocks as HTML comments to the markdown pages. This makes it simpler to integrate them into https://clustercockpit.org/docs/.