### PR TITLE
add tooltip field to metricconfig struct

### DIFF
--- a/schema/cluster.go
+++ b/schema/cluster.go
@@ -100,6 +100,7 @@ type MetricConfig struct {
 	Scope         MetricScope         `json:"scope"`                 // Metric scope (node, socket, core, etc.)
 	Aggregation   string              `json:"aggregation"`           // Aggregation function (avg, sum, min, max)
 	Footprint     string              `json:"footprint,omitempty"`   // Footprint category
+	Tooltip       string              `json:"tooltip,omitempty"`     // Tooltip text shown in frontend if defined
 	SubClusters   []*SubClusterConfig `json:"subClusters,omitempty"` // Subcluster-specific overrides
 	Timestep      int                 `json:"timestep"`              // Measurement interval in seconds
 	Restrict      bool                `json:"restrict"`              // Restrict visibility to non user roles
@@ -128,6 +129,7 @@ type GlobalMetricListItem struct {
 	Unit         Unit             `json:"unit"`                // Unit of measurement
 	Scope        MetricScope      `json:"scope"`               // Metric scope level
 	Footprint    string           `json:"footprint,omitempty"` // Footprint category
+	Tooltip      string           `json:"tooltip,omitempty"`   // Tooltip text shown in frontend if defined
 	Availability []ClusterSupport `json:"availability"`        // Where this metric is available
 }
 

--- a/schema/schemas/cluster.schema.json
+++ b/schema/schemas/cluster.schema.json
@@ -56,6 +56,10 @@
               "min"
             ]
           },
+          "tooltip": {
+            "description": "Shortly describes the metric",
+            "type": "string"
+          },
           "energy": {
             "description": "Is it used to calculate job energy",
             "type": "string",


### PR DESCRIPTION
## Relation

Related to `cc-backend` issue https://github.com/ClusterCockpit/cc-backend/issues/565

## Content

Adds `tooltip` field to Metric Configuration Struct and Global Metric List item Struct